### PR TITLE
Integrations: Link Portable

### DIFF
--- a/integrations.md
+++ b/integrations.md
@@ -43,6 +43,11 @@ These lists are provided for informational purposes to highlight potentially int
   - [GitHub](https://github.com/flavio/podlock)
   - Sandboxer for Kubernetes Pods
 
+* - [Portable]([https://flavio.github.io/podlock](https://github.com/Kraftland/portable))
+  - Sandboxer
+  - GitHub repository
+  - Fast, private, modern sandbox designed for desktop Linux
+
 * - [dosemu2](https://github.com/dosemu2/dosemu2)
   - Emulator
   - Merged [GitHub PR](https://github.com/dosemu2/dosemu2/pull/2344)

--- a/integrations.md
+++ b/integrations.md
@@ -43,6 +43,11 @@ These lists are provided for informational purposes to highlight potentially int
   - [GitHub](https://github.com/flavio/podlock)
   - Sandboxer for Kubernetes Pods
 
+* - [Portable](https://github.com/Kraftland/portable)
+  - Sandboxer
+  - GitHub repository
+  - Fast, private, modern sandbox designed for desktop Linux
+
 * - [dosemu2](https://github.com/dosemu2/dosemu2)
   - Emulator
   - Merged [GitHub PR](https://github.com/dosemu2/dosemu2/pull/2344)


### PR DESCRIPTION
Added a new entry for Portable with a description.

Portable now uses landlock for blocking signal sending to the host system, and has a pending change to enable filesystem sandboxing in addition to bind mounting.

https://github.com/Kraftland/portable/pull/721
https://github.com/Kraftland/portable/pull/722